### PR TITLE
update to gtk 3.24.23 and switch to macports

### DIFF
--- a/gtk/mac/10.13/gtk-bin.tar.gz
+++ b/gtk/mac/10.13/gtk-bin.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c6118a810da31d4e1c2f18b0f73635082cbd94602032fbce1abc6f9f91edd35
-size 139523466
+oid sha256:4f2ca991fa503d31d2987adf5a9960a8b8444bee7f1b39ba00e0bfbd287f5146
+size 334186707


### PR DESCRIPTION
This is the build environment produced with the updated
macos build environment from the pull request:

https://github.com/xournalpp/xournalpp/pull/2390